### PR TITLE
Fixed deprecated use of Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Bitcoin Wallet Import Format encoding/decoding module.
 
 ``` javascript
 var wif = require('wif')
-var privateKey = new Buffer('0000000000000000000000000000000000000000000000000000000000000001', 'hex')
+var privateKey = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex')
 var key = wif.encode(128, privateKey, true)
 // => KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Bitcoin Wallet Import Format encoding/decoding module.
 ``` javascript
 var wif = require('wif')
 var privateKey = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex')
-var key = wif.encode(128, privateKey, true)
+var key = wif.encode(128, privateKey, true) // for the testnet use: wif.encode(239, ...
 // => KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn
 
 var obj = wif.decode(key)


### PR DESCRIPTION
which eliminates the warning:

(node:69912) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.